### PR TITLE
Add year selection to TUİK scraper via --yyyy argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ pip install -r requirements.txt   # install project requirements inside the venv
    To scrape the whole of Türkiye (aggregated polygons at admin level 2), pass the literal string `Türkiye`:
    ```bash
    python scripts/run_script.py --il Türkiye
+   ```bash
+   !New! You can specify which your you want to scrape by providing --yyyy argument
+   python scripts/run_script.py --il Türkiye --yyyy 2022
    ```
 
 3. **Hook the map when prompted**

--- a/scripts/run_script.py
+++ b/scripts/run_script.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import argparse
+from datetime import date
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -9,10 +10,16 @@ from tuik_scraper.scraper import scrape_tuik
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run TUİK scraper for a specific il (province).")
     parser.add_argument("--il", type=str, nargs="+", required=True, help="Name of the province (e.g., Yalova)")
+    parser.add_argument("--yyyy", type=int, nargs="?", required=False, help="Year of the statistics",default=(date.today().year)-1)
     #parser.add_argument("-tr",type=str,required=False, help="Scrape the whole country")
 
     args = parser.parse_args()
 
-    print(f"🚀 Starting TUİK scraper for {args.il}...")
-    scrape_tuik(il=args.il)
+    # Exit if the year is invalid
+    if args.yyyy>(date.today().year)-1:
+        print(f"Latest data collection year is {(date.today().year)-1}. Enter a year between 2022 and {(date.today().year)-1}")
+        sys.exit(1)
+
+    print(f"🚀 Starting TUİK scraper for {args.il} in {args.yyyy}...")
+    scrape_tuik(il=args.il,year = args.yyyy)
     print("✅ Done.")

--- a/tuik_scraper/utils.py
+++ b/tuik_scraper/utils.py
@@ -62,17 +62,13 @@ def save_to_csv(data, path):
 
     # Choose one of the two output styles:
 
-    # (1) Single CSV that appends & rotates:
+    # Single CSV that appends & rotates:
     target = ensure_target_file(path)
     write_header = not target.exists()
     df.to_csv(target, mode='a', header=write_header, index=False, encoding='utf-8')
     print(f"💾 Appended {len(df)} rows → {target}")
 
-    # (2) OPTIONAL: Compressed shards (smaller on disk):
-    # shard = path.with_suffix('')  # base name
-    # shard = shard.with_name(f"{path.stem}_{datetime.now():%Y%m%d_%H%M%S}.csv.gz")
-    # df.to_csv(shard, index=False, encoding='utf-8', compression='gzip')
-    # print(f"💾 Wrote {len(df)} rows → {shard} (gzip)")
+
 
 
 


### PR DESCRIPTION
Introduces a --yyyy argument to scripts/run_script.py, allowing users to specify the year of statistics to scrape. Updates the README with usage instructions, adds validation for the year, and modifies scraper logic to select the correct year in the web interface. Refactors related functions to support the year parameter.